### PR TITLE
[FIX] use path relative to location of get_mask file to get the masks

### DIFF
--- a/deepmreye/preprocess.py
+++ b/deepmreye/preprocess.py
@@ -92,7 +92,7 @@ def run_participant(fp_func, dme_template, eyemask_big, eyemask_small, x_edges, 
 # --------------------------------------------------------------------------------
 # --------------------------MASKING-----------------------------------------------
 # --------------------------------------------------------------------------------
-def get_masks(data_path='../deepmreye/masks/'):
+def get_masks(data_path=''):
     """Loads masks for whole brain, big eye mask and small eye mask
 
     Parameters
@@ -117,6 +117,10 @@ def get_masks(data_path='../deepmreye/masks/'):
     z_edges : list
         Edges of mask in z-dimension
     """     
+
+    if data_path == "":
+        data_path = os.path.abspath(os.path.join(__file__, "..", "masks"))
+
     eyemask_small = ants.image_read(os.path.join(data_path, 'eyemask_small.nii'))
     eyemask_big = ants.image_read(os.path.join(data_path,  'eyemask_big.nii'))
     dme_template = ants.image_read(os.path.join(data_path, 'dme_template.nii'))


### PR DESCRIPTION
ok this should be the actual fix for #6 

To test it, make sure that the MWE mention in [here](https://github.com/DeepMReye/DeepMReye/issues/6#issuecomment-989632244) does produce the bug.

Then uninstall deepmreye install the version from my branch with the fix:

```
pip uninstall deepmreye
pip install git+https://github.com/Remi-Gau/DeepMReye.git@remi-6-get_masks
```

And rerun the "test" to make sure the masks and templates are found.

### launch iPython
```
ipython
```

### try to get the masks
```
from deepmreye import preprocess
(
    eyemask_small,
    eyemask_big,
    dme_template,
    mask,
    x_edges,
    y_edges,
    z_edges,
) = preprocess.get_masks()
```