### PR TITLE
Explicitly add files in masks folder for install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,6 @@ setup(
     packages=find_packages(),
     package_data={
         "": ["*.p", "*.nii", "*.csv", "*.npz", "*.png", "*.txt"],
+        "deepmreye": ["deepmreye/masks/*", "tests/data/*"]
     },
 )


### PR DESCRIPTION
Address #6  (and possibly closes it).

This is a quick fix attempt to close #6. In theory what you expressed should have been enough, in practice let's see if adding more specificity to the setup helps.
Worth a try - works for me on Linux.

Another cause of this issue might be some local configuration that doesn't allow for nifti files of files bigger than x MB.