### PR TITLE
Automatically download masks to folder if they dont exist

### DIFF
--- a/deepmreye/preprocess.py
+++ b/deepmreye/preprocess.py
@@ -7,6 +7,7 @@ from mpl_toolkits.axes_grid1.axes_divider import make_axes_locatable
 from scipy.io import loadmat
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
+from deepmreye.util.data_io import download_mask
 
 # --------------------------------------------------------------------------------
 # --------------------------ANTS TRANSFORMS---------------------------------------
@@ -117,13 +118,20 @@ def get_masks(data_path=''):
     z_edges : list
         Edges of mask in z-dimension
     """     
+    def load_from_path(fn_mask):
+        if os.path.exists(fn_mask):
+            return ants.image_read(fn_mask)
+        else:
+            print('Downloading mask: {}'.format(fn_mask))
+            download_mask(fn_mask)
+            return ants.image_read(fn_mask)
 
     if data_path == "":
         data_path = os.path.abspath(os.path.join(__file__, "..", "masks"))
 
-    eyemask_small = ants.image_read(os.path.join(data_path, 'eyemask_small.nii'))
-    eyemask_big = ants.image_read(os.path.join(data_path,  'eyemask_big.nii'))
-    dme_template = ants.image_read(os.path.join(data_path, 'dme_template.nii'))
+    eyemask_small = load_from_path(os.path.join(data_path, 'eyemask_small.nii'))
+    eyemask_big = load_from_path(os.path.join(data_path,  'eyemask_big.nii'))
+    dme_template = load_from_path(os.path.join(data_path, 'dme_template.nii'))
     (mask, x_edges, y_edges, z_edges) = get_mask_edges(mask=eyemask_small)
     return eyemask_small, eyemask_big, dme_template, mask, x_edges, y_edges, z_edges
 

--- a/deepmreye/util/data_io.py
+++ b/deepmreye/util/data_io.py
@@ -1,3 +1,5 @@
+import os
+import urllib
 import numpy as np
 from scipy.io import loadmat
 
@@ -130,3 +132,17 @@ def get_all_subject_labels_mmd(subject_string, run_idx, num_downsampled=10):
                               if x.size > 0 else np.zeros((num_downsampled, 2)) * np.nan for x in this_run])
         return all_subtr
     return np.array([])
+
+
+# --------------------------------------------------------------------------------
+# --------------------------IO-MASKS----------------------------------------------
+# --------------------------------------------------------------------------------
+
+
+def download_mask(data_path, remote_path='https://github.com/DeepMReye/DeepMReye/blob/main/deepmreye/masks/'):
+    mask_name = os.path.basename(data_path)
+    mask_remote = remote_path + '{}?raw=true'.format(mask_name)
+    try:
+        (f, m) = urllib.request.urlretrieve(mask_remote, data_path)
+    except urllib.error.URLError as e:
+        raise RuntimeError("Failed to download '{}'. '{}'".format(mask_remote, e.reason))

--- a/tests/test_deepmreye.py
+++ b/tests/test_deepmreye.py
@@ -7,6 +7,13 @@ from deepmreye.util import model_opts, data_generator
 # --------------------------------------------------------------------------------
 # --------------------------PREPROCESSING-----------------------------------------
 # --------------------------------------------------------------------------------
+def test_download(path_to_masks):
+    # Delete files if already in folder to see if download works
+    for m in ['eyemask_small.nii', 'eyemask_big.nii', 'dme_template.nii']:
+        if os.path.exists(path_to_masks + m):
+            os.remove(path_to_masks + m)
+    test_masks(path_to_masks)
+
 def test_masks(path_to_masks):
     (eyemask_small, eyemask_big, dme_template, mask, x_edges, y_edges, z_edges) = preprocess.get_masks(path_to_masks)
     for m in [eyemask_small, eyemask_big, dme_template, mask]:


### PR DESCRIPTION
This should fix #6 by downloading files directly to the folder if not present after installation of packages (see also discussion in #11). Also includes a new unit test that explicitly deletes the masks and checks if the download is possible. 