### PR TITLE
[FIX] use old default value for tensorflow keras AveragePooling3D

### DIFF
--- a/deepmreye/architecture.py
+++ b/deepmreye/architecture.py
@@ -197,7 +197,7 @@ def conv3d_block(input_layer, filters, kernel_size, strides, activation):
                    strides=(1, 1, 1),
                    padding='same',
                    activation=activation)(input_layer)
-        x = AveragePooling3D()(x)
+        x = AveragePooling3D(pool_size=(2, 2, 2))(x)
     else:
         x = Conv3D(filters=filters,
                    kernel_size=(kernel_size, kernel_size, kernel_size),


### PR DESCRIPTION
- fixes #60

older version of tensorflow had a default value for the pool_size of AveragePooling3D

https://github.com/keras-team/keras/blob/v2.15.0/keras/layers/pooling/average_pooling3d.py#L88C9-L88C28

this is not the case in more recent versions

https://github.com/keras-team/keras/blob/e6e62405fa1b4444102601636d871610d91e5783/keras/layers/pooling/average_pooling3d.py#L67

For the fix, the old default value is passed.